### PR TITLE
[RATOM-111] addresses a few safari related issues

### DIFF
--- a/src/components/Components/Buttons/ActionButton.js
+++ b/src/components/Components/Buttons/ActionButton.js
@@ -6,6 +6,7 @@ const ActionButton = ({ children, ...props }) => {
 };
 
 const ActionButtonStyled = styled.button`
+  background-color: ${props => props.theme.primaryBackground};
   min-width: 20rem;
   border-radius: 4px;
   border: 2px solid ${props => props.theme.colorPrimary};

--- a/src/components/Components/Buttons/Button.js
+++ b/src/components/Components/Buttons/Button.js
@@ -7,6 +7,7 @@ const ButtonStyled = styled.button`
   padding: 1rem 2rem;
   font-weight: bold;
   border-radius: ${borderRadius};
+  background-color: white;
 
   opacity: ${props => (props.disabled ? 0.6 : 1)};
   font-size: ${props => (props.small ? '1rem' : '1.5rem')};
@@ -20,7 +21,7 @@ const ButtonStyled = styled.button`
     }
 
     if (props.neutral) {
-      return props.theme.colorWhite;
+      return props.theme.backgroundPrimary;
     }
 
     if (props.negative) {

--- a/src/util/dateToIso.js
+++ b/src/util/dateToIso.js
@@ -1,5 +1,9 @@
 import { format } from 'date-fns';
 
-const dateToIso = date => format(new Date(date), 'yyyy-MM-dd');
+const dateToIso = date => {
+  // Safari sucks at dates, evidently. If date doesn't contain literal T between date and time (ISO8601), add it...
+  const safeDate = date.replace(' ', 'T');
+  return format(new Date(safeDate), 'yyyy-MM-dd');
+};
 
 export default dateToIso;


### PR DESCRIPTION
I don't know that we're actively supporting safari here, but these were easy enough to fix.
Safari has some strong opinions about datetime formatting in the js Date constructor. It wants a strict compliance with ISO8601, and some of our dates come in with the 'T' between date and time (**gasp). So that's been added.
Also fixed some styling that allowed safari to override background colors on buttons.