### PR TITLE
[RATOM-106] add account id filter to query params

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -36,18 +36,8 @@ Cypress.Commands.add('goToMessagesList', () => {
   cy.get('[data-cy="accounts_list_item"]')
     .first()
     .within(() => {
-      cy.get('[data-cy="account-detail-dot-menu"]').click({ force: true });
-
-      cy.get('[data-cy="dropdown-menu"]')
-        .children()
-        .first()
-        .within(() => {
-          cy.contains('View').click({ force: true });
-        });
-      // .children()
-      // .first()
-      // .first()
-      // .children()
-      // .click({ force: true });
+      cy.get('[data-cy="account-detail-dot-menu"]').click();
+      cy.wait(200);
+      cy.contains('View').click({ force: true });
     });
 });

--- a/src/components/Containers/Messages/MessagesMain.js
+++ b/src/components/Containers/Messages/MessagesMain.js
@@ -23,8 +23,8 @@ export const AccountContext = createContext(null);
 // TODO: Good candidate for a Reducer.
 
 const MessagesMain = () => {
-  const [account, setAccount] = useState();
   const { accountId } = useParams();
+  const [account, setAccount] = useState();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState();
   const [messages, setMessages] = useState();
@@ -51,8 +51,9 @@ const MessagesMain = () => {
 
   const searchMessages = () => {
     setLoading(true);
+    const accountParam = `account=${accountId}&`;
     const queryParams = constructQueryString(query);
-    const url = SEARCH_MESSAGES + queryParams;
+    const url = SEARCH_MESSAGES + accountParam + queryParams;
     Axios.get(url)
       .then(response => {
         updateResults(response.data);


### PR DESCRIPTION
API is now set up to accept 'account=<id>' query param for filtering. So added that. We're grabbing accountID from the url so that users can navigate directly to "accounts/2" and still filter on the right account.