### PR TITLE
[RATOM-120] infelicitous preservation of query details

### DIFF
--- a/cypress/integration/filter-panel.spec.js
+++ b/cypress/integration/filter-panel.spec.js
@@ -5,6 +5,14 @@ describe('Filter panel behavior', () => {
     cy.initialize_account();
   });
 
+  /* It turns out we can't really test for things that depend on local storage 
+            as this data is not really there in cypress. */
+  // describe('Queries are preserved per account', () => {
+  //   it('expect saved queries to be different for different accounts', () => {
+
+  //   });
+  // });
+
   describe('Limit to account', () => {
     it('having selected an account to view, filtering messages returns only messages from that account', () => {
       const accountId = Cypress.env('accountId');

--- a/src/components/Containers/Messages/MessagesMain.js
+++ b/src/components/Containers/Messages/MessagesMain.js
@@ -34,8 +34,8 @@ const MessagesMain = () => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState();
   const [messages, setMessages] = useState();
-  const [query, setQueryLocally] = useState(getFilterQueryFromLocalStorage() || emptyQuery);
-  const [filterQuery, setFilterQuery] = useState(getFilterQueryFromLocalStorage() || emptyQuery);
+  const [query, setQueryLocally] = useState(getFilterQueryFromLocalStorage(accountId));
+  const [filterQuery, setFilterQuery] = useState(getFilterQueryFromLocalStorage(accountId));
   const [messagesTotalCount, setMessagesTotalCount] = useState();
   const [listPlaceholder, setListPlaceholder] = useState();
   const [messageCursor, setMessageCursor] = useState();
@@ -108,7 +108,9 @@ const MessagesMain = () => {
   };
 
   const setQuery = newQuery => {
-    setFilterQueryToLocalStorage(newQuery);
+    // this sets query to local storage
+    setFilterQueryToLocalStorage(accountId, newQuery);
+    // this triggers an API call
     setQueryLocally(newQuery);
   };
 

--- a/src/localStorageUtils/queryManager.js
+++ b/src/localStorageUtils/queryManager.js
@@ -4,7 +4,17 @@ import {
   removeValueFromLocalStorage
 } from './localStorageManager';
 import { FILTER_QUERY } from '../constants/localStorageConstants';
+import emptyQuery from '../components/Containers/Messages/emptyQuery';
 
-export const getFilterQueryFromLocalStorage = () => getValueFromLocalStorage(FILTER_QUERY);
-export const setFilterQueryToLocalStorage = value => setValueToLocalStorage(FILTER_QUERY, value);
+export const getFilterQueryFromLocalStorage = accountId => {
+  const queryList = getValueFromLocalStorage(FILTER_QUERY);
+  return (queryList && queryList[accountId]) || emptyQuery;
+};
+export const setFilterQueryToLocalStorage = (accountId, value) => {
+  const queryList = getValueFromLocalStorage(FILTER_QUERY);
+  setValueToLocalStorage(FILTER_QUERY, {
+    ...queryList,
+    [accountId]: value
+  });
+};
 export const removeFilterQueryFromLocalStorage = () => removeValueFromLocalStorage(FILTER_QUERY);


### PR DESCRIPTION
queryFilter in localStorage now looks like:

```
{
  "2": {
    "dateRange": [],
    "keywords": [],
    ...etc
  }, 
  "1": {...}
}
```
