### PR TITLE
[RATOM-203] UI for export

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -26,6 +26,7 @@
     "react/no-danger": "off",
     "import/no-cycle": "off",
     "import/order": "off",
-    "camelcase": "warn"
+    "camelcase": "warn",
+    "consistent-return": "warn"
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -25,6 +25,7 @@
     "react/destructuring-assignment": "off",
     "react/no-danger": "off",
     "import/no-cycle": "off",
-    "import/order": "off"
+    "import/order": "off",
+    "camelcase": "warn"
   }
 }

--- a/cypress/integration/export.spec.js
+++ b/cypress/integration/export.spec.js
@@ -1,0 +1,25 @@
+describe('Export behavior', () => {
+  before(() => {
+    cy.login();
+    cy.initialize_account();
+    cy.goToMessagesList();
+    cy.enterKeywordFilters(['send']);
+    cy.server();
+    cy.route('GET', `/api/v1/export/?account=1&`).as('filterMessages');
+  });
+
+  it('downloads a file', () => {
+    cy.exportAsRecordsRequest();
+    cy.server();
+    cy.wait('@filterMessages').should(xhr => {
+      const { status, response } = xhr;
+      const contentType = response.headers['content-type'];
+      const contentDisposition = response.headers['content-disposition'];
+      expect(status).to.eq(200);
+      expect(contentType).to.eq('application/x-gzip');
+      expect(contentDisposition).to.include('.txt.gz');
+      expect(contentDisposition).to.include('attachment;');
+      expect(contentDisposition).to.include('filename=');
+    });
+  });
+});

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -118,3 +118,9 @@ Cypress.Commands.add('addArbitraryLabels', labels => {
     cy.get('[data-cy="add_label_input"]').type(`${label} {enter}`);
   }
 });
+
+Cypress.Commands.add('exportAsRecordsRequest', () => {
+  cy.get('[data-cy="export-as-records-request-button"]').click();
+  cy.wait(500);
+  cy.get('[data-cy="export-button"]').click();
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -6573,6 +6573,11 @@
         "schema-utils": "^1.0.0"
       }
     },
+    "file-saver": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/file-saver/-/file-saver-2.0.2.tgz",
+      "integrity": "sha512-Wz3c3XQ5xroCxd1G8b7yL0Ehkf0TC9oYC6buPFkNnU9EnaPlifeAFCyCh+iewXTyFRcg0a6j3J7FmJsIhlhBdw=="
+    },
     "file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "axios-hooks": "^1.9.0",
     "babel-eslint": "^10.0.3",
     "date-fns": "^2.7.0",
+    "file-saver": "^2.0.2",
     "framer-motion": "^1.8.3",
     "lodash.isempty": "^4.4.0",
     "moment": "^2.24.0",

--- a/src/App.js
+++ b/src/App.js
@@ -50,7 +50,8 @@ const AppStyled = styled.div`
 const alertOptions = {
   timeout: ALERT_TIMEOUT,
   position: positions.TOP_CENTER,
-  transitions: transitions.FADE
+  transitions: transitions.FADE,
+  containerStyle: { zIndex: 1001 }
 };
 
 export default App;

--- a/src/components/Components/Animated/AnimatedModal.js
+++ b/src/components/Components/Animated/AnimatedModal.js
@@ -1,20 +1,23 @@
 import React from 'react';
+import ReactDOM from 'react-dom';
 import { motion, AnimatePresence } from 'framer-motion';
 import styled from 'styled-components';
 import { boxShadow } from '../../../styles/styleVariables';
+import usePortal from '../../Hooks/usePortal';
 
 const AnimatedModal = ({ isVisible, closeModal, children, ...props }) => {
-  return (
+  const portalTarget = usePortal('portal-root');
+  return ReactDOM.createPortal(
     <AnimatePresence>
       {isVisible && [
-        // <StyledShade
-        //   key="shade"
-        //   onClick={closeModal}
-        //   initial={{ opacity: 0 }}
-        //   animate={{ opacity: 1 }}
-        //   exit={{ opacity: 0 }}
-        //   positionTransition
-        // />,
+        <StyledShade
+          key="shade"
+          onClick={closeModal}
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          positionTransition
+        />,
         <StyledModal
           {...props}
           key="modal"
@@ -22,31 +25,32 @@ const AnimatedModal = ({ isVisible, closeModal, children, ...props }) => {
             duration: 0.25,
             ease: 'linear'
           }}
-          initial={{ opacity: 0, scale: 0.9 }}
-          animate={{ opacity: [0, 1, 1], scale: [0.9, 0.95, 1] }}
-          exit={{ opacity: 0, scale: 0.9 }}
+          initial={{ opacity: 0, scale: 0.9, x: '-50%', y: '-50%' }}
+          animate={{ opacity: [0, 1, 1], scale: [0.9, 0.95, 1], x: '-50%', y: '-50%' }}
+          exit={{ opacity: 0, scale: 0.9, x: '-50%', y: '-50%' }}
           positionTransition
         >
           {children}
         </StyledModal>
       ]}
-    </AnimatePresence>
+    </AnimatePresence>,
+    portalTarget
   );
 };
 
-// });
-
-// const StyledShade = styled(motion.div)`
-//   position: absolute;
-//   background: rgba(0, 0, 0, 0.8);
-//   top: 0;
-//   left: 0;
-//   right: 0;
-//   bottom: 0;
-// `;
+const StyledShade = styled(motion.div)`
+  z-index: 999;
+  position: absolute;
+  background: rgba(0, 0, 0, 0.8);
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+`;
 
 const StyledModal = styled(motion.div)`
   position: absolute;
+  z-index: 1000;
   width: 500px;
   height: 300px;
   background-color: ${props => props.theme.primaryBackground};

--- a/src/components/Components/Animated/AnimatedModal.js
+++ b/src/components/Components/Animated/AnimatedModal.js
@@ -50,6 +50,8 @@ const StyledShade = styled(motion.div)`
 
 const StyledModal = styled(motion.div)`
   position: absolute;
+  top: 50%;
+  left: 50%;
   z-index: 1000;
   width: 500px;
   height: 300px;

--- a/src/components/Components/Loading/Spinner.js
+++ b/src/components/Components/Loading/Spinner.js
@@ -23,9 +23,12 @@ const Spinner = props => {
   useEffect(() => {
     // Don't show spinner right away-- let fast stuff happen fast.
     // TODO: Ideally, this would be wrapped at a higher level so that the original content doesn't flash away.
-    let timeout = setTimeout(() => setShow(true), 500);
-    return () => clearTimeout(timeout);
-  }, []);
+    if (props.immediate) setShow(true);
+    else {
+      const timeout = setTimeout(() => setShow(true), 500);
+      return () => clearTimeout(timeout);
+    }
+  }, [props]);
 
   if (!show) return null;
   return (

--- a/src/components/Components/Pagination/Pagination.js
+++ b/src/components/Components/Pagination/Pagination.js
@@ -11,7 +11,7 @@ const Pagination = props => {
   return (
     <PaginationStyled {...props}>
       <ResultsTotals>
-        <h4>Showing </h4> <MessagesCount>{messages.length}</MessagesCount>
+        <h4>Displaying </h4> <MessagesCount>{messages.length}</MessagesCount>
         <h4>of </h4> <h5 data-cy="search-results__count">{messagesTotalCount}</h5>
       </ResultsTotals>
     </PaginationStyled>

--- a/src/components/Containers/Accounts/AccountImportModal.js
+++ b/src/components/Containers/Accounts/AccountImportModal.js
@@ -141,8 +141,6 @@ const AccountImportModal = ({ closeModal, isVisible }) => {
 
 const AccountImportModalStyled = styled(AnimatedModal)`
   z-index: 1000;
-  top: 0;
-  left: 0;
   height: 100vh;
   width: 100vw;
   padding: 4rem;

--- a/src/components/Containers/Messages/AccountExportModal.js
+++ b/src/components/Containers/Messages/AccountExportModal.js
@@ -1,0 +1,203 @@
+import React, { useEffect, useState, useContext } from 'react';
+import styled from 'styled-components';
+import AnimatedModal from '../../Components/Animated/AnimatedModal';
+import {
+  colorPrimary,
+  colorBlackLight,
+  colorBadgeRed,
+  boxShadow
+} from '../../../styles/styleVariables';
+
+// Contexgt
+import { AccountContext } from './MessagesMain';
+
+// Children
+import Button from '../../Components/Buttons/Button';
+import { motion, AnimatePresence } from 'framer-motion';
+import Spinner from '../../Components/Loading/Spinner';
+
+const AccountExportModal = ({ closeModal, isVisible }) => {
+  const { messagesTotalCount, facets } = useContext(AccountContext);
+  const [exporting, setExporting] = useState(false);
+  const [processedCount, setProcessedCount] = useState('');
+  const [unprocessedCount, setUnprocessedCount] = useState('');
+  const [restrictedCount, setRestrictedCount] = useState('');
+  const [redactedCount, setRedactedCount] = useState('');
+  const [nonrecordCount, setNonrecordCount] = useState('');
+
+  useEffect(() => {
+    const {
+      _filter_processed,
+      _filter_is_restricted,
+      _filter_needs_redaction,
+      _filter_is_record
+    } = facets;
+    const processedBucket = _filter_processed.processed.buckets.find(
+      b => b.key_as_string === 'true'
+    );
+
+    const unprocessedBucket = _filter_processed.processed.buckets.find(
+      x => x.key_as_string === 'false'
+    );
+    const restrictedBucket = _filter_is_restricted.is_restricted.buckets.find(
+      b => b.key_as_string === 'true'
+    );
+    const redactedBucket = _filter_needs_redaction.needs_redaction.buckets.find(
+      b => b.key_as_string === 'true'
+    );
+    const nonrecordBucket = _filter_is_record.is_record.buckets.find(
+      b => b.key_as_string === 'false'
+    );
+
+    if (processedBucket) setProcessedCount(processedBucket.doc_count);
+    else setProcessedCount('');
+    if (unprocessedBucket) setUnprocessedCount(unprocessedBucket.doc_count);
+    else setUnprocessedCount('');
+    if (restrictedBucket) setRestrictedCount(restrictedBucket.doc_count);
+    else setRestrictedCount('');
+    if (redactedBucket) setRedactedCount(redactedBucket.doc_count);
+    else setRedactedCount('');
+    if (nonrecordBucket) setNonrecordCount(nonrecordBucket.doc_count);
+    else setNonrecordCount('');
+  }, [facets]);
+
+  const handleExport = () => {
+    // TODO do actual export.
+    setExporting(true);
+    setTimeout(() => {
+      setExporting(false);
+      closeModal();
+    }, 4000);
+  };
+
+  return (
+    <AccountExportModalStyled closeModal={exporting ? undefined : closeModal} isVisible={isVisible}>
+      <AnimatePresence exitBeforeEnter initial={false}>
+        {exporting ? (
+          <LoadingContent
+            key="loadingContent"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{
+              duration: 0.25,
+              ease: 'linear'
+            }}
+          >
+            <h4>Processesing Export...</h4>
+            <Spinner large immediate />
+          </LoadingContent>
+        ) : (
+          <ExportContent
+            key="exportContent"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{
+              duration: 0.25,
+              ease: 'linear'
+            }}
+          >
+            <Warning>
+              Export <span>{messagesTotalCount}</span> messages?
+            </Warning>
+            <ExportDetails>
+              {processedCount && processedCount >= 0 && (
+                <DetailItem>
+                  <span>{processedCount}</span> Processed
+                </DetailItem>
+              )}
+              {nonrecordCount && nonrecordCount >= 0 && (
+                <DetailItem>
+                  <span>{nonrecordCount}</span> Non-record
+                </DetailItem>
+              )}
+              {unprocessedCount && unprocessedCount >= 0 && (
+                <DetailItem caution>
+                  <span>{unprocessedCount}</span> Unprocessed
+                </DetailItem>
+              )}
+              {redactedCount && redactedCount >= 0 && (
+                <DetailItem caution>
+                  <span>{redactedCount}</span> {redactedCount === 1 ? 'Needs' : 'Need'} Redaction
+                </DetailItem>
+              )}
+              {restrictedCount && restrictedCount >= 0 && (
+                <DetailItem caution>
+                  <span>{restrictedCount}</span> Restricted
+                </DetailItem>
+              )}
+            </ExportDetails>
+            <Actions>
+              <Button neutral onClick={closeModal}>
+                Cancel
+              </Button>
+              <Button positive onClick={handleExport}>
+                Export
+              </Button>
+            </Actions>
+          </ExportContent>
+        )}
+      </AnimatePresence>
+    </AccountExportModalStyled>
+  );
+};
+
+const ExportContent = styled(motion.div)`
+  height: auto;
+  width: auto;
+  padding: 4rem 4rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+const LoadingContent = styled(motion.div)`
+  height: auto;
+  width: auto;
+  padding: 4rem 4rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+const Warning = styled.h2`
+  span {
+    color: ${colorPrimary};
+  }
+`;
+
+const ExportDetails = styled.div`
+  margin-bottom: 4rem;
+`;
+
+const DetailItem = styled.p`
+  font-size: 1.5rem;
+  margin-bottom: 1rem;
+  color: ${props => (props.caution ? colorBadgeRed : colorBlackLight)};
+`;
+
+const Actions = styled.div`
+  width: 100%;
+  min-width: 25rem;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+const AccountExportModalStyled = styled(AnimatedModal)`
+  z-index: 1000;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  height: auto;
+  width: auto;
+  /* padding: 4rem 4rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center; */
+  box-shadow: ${boxShadow};
+`;
+
+export default AccountExportModal;

--- a/src/components/Containers/Messages/MessagesContent/ResultsSummary.js
+++ b/src/components/Containers/Messages/MessagesContent/ResultsSummary.js
@@ -22,7 +22,9 @@ const ResultsSummary = () => {
           </h3>
         </Summary>
         <Actions>
-          <p onClick={() => setShowExportModal(true)}>Export as Records Request</p>
+          <p data-cy="export-as-records-request-button" onClick={() => setShowExportModal(true)}>
+            Export as Records Request
+          </p>
         </Actions>
       </ResultsSummaryStyled>
       <AccountExportModal

--- a/src/components/Containers/Messages/MessagesContent/ResultsSummary.js
+++ b/src/components/Containers/Messages/MessagesContent/ResultsSummary.js
@@ -1,14 +1,35 @@
-import React from 'react';
+import React, { useContext, useState } from 'react';
 import styled from 'styled-components';
-import { borderSeparator, standardPadding } from '../../../../styles/styleVariables';
+import { borderSeparator, standardPadding, colorPrimary } from '../../../../styles/styleVariables';
+
+// Context
+import { AccountContext } from '../MessagesMain';
+import formatNumber from '../../../../util/formatNumber';
+import AccountExportModal from '../AccountExportModal';
 
 const ResultsSummary = () => {
-  // TODO: @WIP, implement "select all/none",
-  // TODO: make MessageCheckbox usable here too tho
+  const { messages, messagesTotalCount } = useContext(AccountContext);
+  const [showExportModal, setShowExportModal] = useState(false);
+
   return (
-    <ResultsSummaryStyled>
-      <h4>Results Summary</h4>
-    </ResultsSummaryStyled>
+    <>
+      <ResultsSummaryStyled>
+        <Summary>
+          <h3>
+            Displaying <span>{formatNumber(messages.length)}</span> of
+            {messagesTotalCount === 10000 ? ' more than ' : ' '}
+            {formatNumber(messagesTotalCount)} results
+          </h3>
+        </Summary>
+        <Actions>
+          <p onClick={() => setShowExportModal(true)}>Export as Records Request</p>
+        </Actions>
+      </ResultsSummaryStyled>
+      <AccountExportModal
+        isVisible={showExportModal}
+        closeModal={() => setShowExportModal(false)}
+      />
+    </>
   );
 };
 
@@ -17,10 +38,30 @@ const ResultsSummaryStyled = styled.div`
   width: 100%;
   padding: ${standardPadding};
   border-bottom: ${borderSeparator};
+  padding: 0 2rem;
 
   display: flex;
   flex-direction: row;
   align-items: center;
+`;
+
+const Summary = styled.div`
+  flex: 1;
+  h3 {
+    span {
+      color: ${colorPrimary};
+    }
+  }
+`;
+
+const Actions = styled.div`
+  max-width: 25%;
+
+  p {
+    font-size: 1.5rem;
+    cursor: pointer;
+    color: ${colorPrimary};
+  }
 `;
 
 export default ResultsSummary;

--- a/src/components/Containers/Messages/MessagesMain.js
+++ b/src/components/Containers/Messages/MessagesMain.js
@@ -13,16 +13,22 @@ import {
 } from '../../../localStorageUtils/queryManager';
 import emptyQuery from './emptyQuery';
 
-// Children
-import MessagesLayout from './MessagesLayout';
-import MessageMain from '../Message/MessageMain';
-import GenericNotFound from '../GenericNotFound';
+// ls
+import { RECORDS_REQUEST_QUERY } from '../../../constants/localStorageConstants';
+import { setValueToLocalStorage } from '../../../localStorageUtils/localStorageManager';
+
+// Util
 import {
   keywordFilterBuilderAND,
   emailFilterBuilderOR,
   dateRangeFilterBuilderAND,
   labelFilterBuilderOR
 } from '../../../util/filterConstructors';
+
+// Children
+import MessagesLayout from './MessagesLayout';
+import MessageMain from '../Message/MessageMain';
+import GenericNotFound from '../GenericNotFound';
 
 export const AccountContext = createContext(null);
 
@@ -60,6 +66,12 @@ const MessagesMain = () => {
     }
   }, [query, routerState]);
 
+  const saveQueryForExport = queryString => {
+    // only saves after a successful response to a query
+    // This should prevent an export from occurring on "stale" data
+    setValueToLocalStorage(RECORDS_REQUEST_QUERY, queryString);
+  };
+
   const searchMessages = () => {
     setLoading(true);
     const accountParam = `account=${accountId}&`;
@@ -67,6 +79,7 @@ const MessagesMain = () => {
     const url = SEARCH_MESSAGES + accountParam + queryParams;
     Axios.get(url)
       .then(response => {
+        saveQueryForExport(accountParam + queryParams);
         updateResults(response.data);
         setLoading(false);
       })

--- a/src/constants/localStorageConstants.js
+++ b/src/constants/localStorageConstants.js
@@ -5,3 +5,4 @@ export const USER = 'USER';
 
 // FILTER QUERY
 export const FILTER_QUERY = 'FILTER_QUERY';
+export const RECORDS_REQUEST_QUERY = 'RECORDS_REQUEST_QUERY';

--- a/src/services/requests.js
+++ b/src/services/requests.js
@@ -16,3 +16,4 @@ export const RESTART_FILE = 'files/';
 export const SEARCH_MESSAGES = 'messages/?';
 export const SHOW_MESSAGE = 'messages/';
 export const UPDATE_MESSAGE = 'messages/';
+export const RECORDS_REQUEST = 'export/?';


### PR DESCRIPTION
Brings in ["file-saver"](https://www.npmjs.com/package/file-saver) package to help with downloading the response from `/export/?`

The export confirmation modal shows some statistics to the user about the export before they confirm. This serves to warn the user if they are exporting restricted or redacted messages, or just a large amount of unprocessed messages.

There's a spinner and loading message if it takes a long time. So far, locally at least, the download has been nearly instant.