### PR TITLE
Ratom 193 keyword search uses or

### DIFF
--- a/src/components/Containers/Messages/MessagesMain.js
+++ b/src/components/Containers/Messages/MessagesMain.js
@@ -19,7 +19,7 @@ import { setValueToLocalStorage } from '../../../localStorageUtils/localStorageM
 
 // Util
 import {
-  keywordFilterBuilderAND,
+  keywordFilterBuilderOR,
   emailFilterBuilderOR,
   dateRangeFilterBuilderAND,
   labelFilterBuilderOR,
@@ -107,7 +107,7 @@ const MessagesMain = () => {
   const constructQueryString = queryObj => {
     const { keywords, dateRange, processedStatus, recordStatus, addresses, labels } = queryObj;
     const params = [];
-    if (keywords && keywords.length > 0) params.push(keywordFilterBuilderAND(keywords));
+    if (keywords && keywords.length > 0) params.push(keywordFilterBuilderOR(keywords));
     if (dateRange && dateRange.length > 0) params.push(dateRangeFilterBuilderAND(dateRange));
     if (processedStatus) params.push(processedStatusBuilder(processedStatus));
     if (recordStatus) params.push(recordStatusBuilder(recordStatus));

--- a/src/util/filterConstructors.js
+++ b/src/util/filterConstructors.js
@@ -13,7 +13,7 @@ export const keywordFilterBuilderAND = keywords => {
 
 export const keywordFilterBuilderOR = keywords => {
   const keywordsJoined = keywords.join(',');
-  return `search=${keywordsJoined}`;
+  return `search_simple_query_string=${keywordsJoined}`;
 };
 
 export const emailFilterBuilderOR = emails => {

--- a/src/util/filterConstructors.js
+++ b/src/util/filterConstructors.js
@@ -11,6 +11,11 @@ export const keywordFilterBuilderAND = keywords => {
   return `search_simple_query_string=${keywordsJoined}`;
 };
 
+export const keywordFilterBuilderOR = keywords => {
+  const keywordsJoined = keywords.join(',');
+  return `search=${keywordsJoined}`;
+};
+
 export const emailFilterBuilderOR = emails => {
   // Need to lower case inputs for elasticsearch purposes (email analyzer is lowercasing, wildcard expects case sensitive match)
   const lowerEmails = emails.map(email => email.toLowerCase());


### PR DESCRIPTION
I went back and forth on this as to whether we should build out a custom backend to handle `and`s and `or`s, and in the end it seems in this case to be easier --until necessary based on expanded search and filtering capabilities-- to just switch the default back to `or`. I left the `and` function in place just in case we need it in the future, but it is technically dead code atm so if I'm open to removing it.