### PR TITLE
[RATOM-223] deselect messages after query

### DIFF
--- a/src/components/Containers/Messages/AccountExportModal.js
+++ b/src/components/Containers/Messages/AccountExportModal.js
@@ -25,6 +25,7 @@ import Button from '../../Components/Buttons/Button';
 import Spinner from '../../Components/Loading/Spinner';
 import { RECORDS_REQUEST_QUERY } from '../../../constants/localStorageConstants';
 import { getValueFromLocalStorage } from '../../../localStorageUtils/localStorageManager';
+import useKeyPress from '../../Hooks/useKeyPress';
 
 const AccountExportModal = ({ closeModal, isVisible }) => {
   const alert = useAlert();
@@ -35,6 +36,8 @@ const AccountExportModal = ({ closeModal, isVisible }) => {
   const [restrictedCount, setRestrictedCount] = useState('');
   const [redactedCount, setRedactedCount] = useState('');
   const [nonrecordCount, setNonrecordCount] = useState('');
+
+  useKeyPress('Escape', closeModal);
 
   useEffect(() => {
     const {

--- a/src/components/Containers/Messages/MessagesContent/MessagesContent.js
+++ b/src/components/Containers/Messages/MessagesContent/MessagesContent.js
@@ -1,9 +1,6 @@
-import React, { createContext, useState, useContext } from 'react';
+import React from 'react';
 import styled from 'styled-components';
 import { borderSeparator, colorWhite } from '../../../../styles/styleVariables';
-
-// Context
-import { AccountContext } from '../MessagesMain';
 
 // Children
 import ResultsSummary from './ResultsSummary';
@@ -11,48 +8,16 @@ import MessagesList from './MessagesList/MessagesList';
 import MessagesActions from './MessagesList/MessagesActions/MessagesActions';
 import Pagination from '../../../Components/Pagination/Pagination';
 
-export const MessagesContext = createContext(null);
-
 const MessagesContent = () => {
-  const { messages } = useContext(AccountContext);
-  const [checkedMessages, setCheckedMessages] = useState([]);
-
-  const checkAllMessages = all => {
-    if (all) {
-      setCheckedMessages(messages.map(m => m.id));
-    } else {
-      setCheckedMessages([]);
-    }
-  };
-
-  const checkMessage = messageId => {
-    const messageIndex = checkedMessages.indexOf(messageId);
-    if (messageIndex > -1) {
-      const messagesWithout = [...checkedMessages];
-      messagesWithout.splice(messageIndex, 1);
-      setCheckedMessages(messagesWithout);
-    } else {
-      setCheckedMessages([...checkedMessages, messageId]);
-    }
-  };
-
   return (
-    <MessagesContext.Provider
-      value={{
-        checkedMessages,
-        checkMessage,
-        checkAllMessages
-      }}
-    >
-      <MessagesContentStyled>
-        <ResultsSummary />
-        <MessagesList />
-        <FixedToBottom>
-          <MessagesActions />
-          <Pagination />
-        </FixedToBottom>
-      </MessagesContentStyled>
-    </MessagesContext.Provider>
+    <MessagesContentStyled>
+      <ResultsSummary />
+      <MessagesList />
+      <FixedToBottom>
+        <MessagesActions />
+        <Pagination />
+      </FixedToBottom>
+    </MessagesContentStyled>
   );
 };
 

--- a/src/components/Containers/Messages/MessagesContent/MessagesList/MessageListItem/MessageListItem.js
+++ b/src/components/Containers/Messages/MessagesContent/MessagesList/MessageListItem/MessageListItem.js
@@ -7,7 +7,6 @@ import { borderSeparator, blueGradient } from '../../../../../../styles/styleVar
 import { useHistory, useLocation } from 'react-router-dom';
 
 // Context
-import { MessagesContext } from '../../MessagesContent';
 import { AccountContext } from '../../../MessagesMain';
 
 // Children
@@ -17,8 +16,9 @@ import MessageListItemContentLeft from './MessageListItemContentLeft';
 const MessageListItem = ({ message, i, ...props }) => {
   const messageRef = useRef();
   const [highlightElement, setHighlightElement] = useState(false);
-  const { checkMessage, checkedMessages } = useContext(MessagesContext);
-  const { listPlaceholder, setListPlaceholder } = useContext(AccountContext);
+  const { listPlaceholder, setListPlaceholder, checkMessage, checkedMessages } = useContext(
+    AccountContext
+  );
   const { pathname } = useLocation();
   const history = useHistory();
 

--- a/src/components/Containers/Messages/MessagesContent/MessagesList/MessagesActions/MessagesActions.js
+++ b/src/components/Containers/Messages/MessagesContent/MessagesList/MessagesActions/MessagesActions.js
@@ -1,36 +1,16 @@
-import React, { useState } from 'react';
+import React from 'react';
 import styled from 'styled-components';
-import {
-  borderSeparator,
-  colorGreyLight,
-  colorPrimary
-} from '../../../../../../styles/styleVariables';
+import { borderSeparator, colorGreyLight } from '../../../../../../styles/styleVariables';
 
 // Children
 import SelectionActions from './SelectionActions';
-import AccountExportModal from '../../../AccountExportModal';
-import Button from '../../../../../Components/Buttons/Button';
 
 const MessagesActions = () => {
-  const [showExportModal, setShowExportModal] = useState(false);
   return (
     <>
       <MessagesActionsStyled>
         <SelectionActions />
-        <Actions>
-          <Button
-            neutral
-            onClick={() => setShowExportModal(true)}
-            data-cy="export-as-records-request-button"
-          >
-            Export
-          </Button>
-        </Actions>
       </MessagesActionsStyled>
-      <AccountExportModal
-        isVisible={showExportModal}
-        closeModal={() => setShowExportModal(false)}
-      />
     </>
   );
 };
@@ -46,16 +26,6 @@ const MessagesActionsStyled = styled.div`
   display: flex;
   flex-direction: row;
   align-items: center;
-`;
-
-const Actions = styled.div`
-  max-width: 25%;
-
-  p {
-    font-size: 1.5rem;
-    cursor: pointer;
-    color: ${colorPrimary};
-  }
 `;
 
 export default MessagesActions;

--- a/src/components/Containers/Messages/MessagesContent/MessagesList/MessagesActions/SelectionActions.js
+++ b/src/components/Containers/Messages/MessagesContent/MessagesList/MessagesActions/SelectionActions.js
@@ -15,7 +15,6 @@ import Axios from '../../../../../../services/axiosConfig';
 import { BATCH_UPDATE_MESSAGES } from '../../../../../../services/requests';
 
 // Context
-import { MessagesContext } from '../../MessagesContent';
 import { AccountContext } from '../../../MessagesMain';
 
 // Children
@@ -25,8 +24,9 @@ import ConfirmActionModal from './ConfirmActionModal';
 
 const SelectionActions = () => {
   const alert = useAlert();
-  const { checkedMessages, checkAllMessages } = useContext(MessagesContext);
-  const { messages, searchMessages } = useContext(AccountContext);
+  const { messages, searchMessages, checkedMessages, checkAllMessages } = useContext(
+    AccountContext
+  );
   const [confirmationModalDetails, setConfirmationModalDetails] = useState({});
   const [checked, setChecked] = useState(false);
   const [indeterminate, setIndeterminate] = useState(false);

--- a/src/components/Containers/Messages/MessagesContent/ResultsSummary.js
+++ b/src/components/Containers/Messages/MessagesContent/ResultsSummary.js
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { useState, useContext } from 'react';
 import styled from 'styled-components';
 import { borderSeparator, standardPadding, colorPrimary } from '../../../../styles/styleVariables';
 
@@ -6,19 +6,33 @@ import { borderSeparator, standardPadding, colorPrimary } from '../../../../styl
 import { AccountContext } from '../MessagesMain';
 import formatNumber from '../../../../util/formatNumber';
 
+// Children
+import AccountExportModal from '../AccountExportModal';
+
 const ResultsSummary = () => {
   const { messages, messagesTotalCount } = useContext(AccountContext);
-
+  const [showExportModal, setShowExportModal] = useState(false);
   return (
-    <ResultsSummaryStyled>
-      <Summary>
-        <h3>
-          Displaying <span>{formatNumber(messages.length)}</span> of
-          {messagesTotalCount === 10000 ? ' more than ' : ' '}
-          {formatNumber(messagesTotalCount)} results
-        </h3>
-      </Summary>
-    </ResultsSummaryStyled>
+    <>
+      <ResultsSummaryStyled>
+        <Summary>
+          <h3>
+            Displaying <span>{formatNumber(messages.length)}</span> of
+            {messagesTotalCount === 10000 ? ' more than ' : ' '}
+            {formatNumber(messagesTotalCount)} results
+          </h3>
+        </Summary>
+        <Actions>
+          <p onClick={() => setShowExportModal(true)} data-cy="export-as-records-request-button">
+            Export as Records Request
+          </p>
+        </Actions>
+      </ResultsSummaryStyled>
+      <AccountExportModal
+        isVisible={showExportModal}
+        closeModal={() => setShowExportModal(false)}
+      />
+    </>
   );
 };
 
@@ -40,6 +54,16 @@ const Summary = styled.div`
     span {
       color: ${colorPrimary};
     }
+  }
+`;
+
+const Actions = styled.div`
+  max-width: 25%;
+
+  p {
+    font-size: 1.5rem;
+    cursor: pointer;
+    color: ${colorPrimary};
   }
 `;
 

--- a/src/components/Containers/Messages/MessagesMain.js
+++ b/src/components/Containers/Messages/MessagesMain.js
@@ -47,6 +47,7 @@ const MessagesMain = () => {
   const [messagesTotalCount, setMessagesTotalCount] = useState();
   const [listPlaceholder, setListPlaceholder] = useState();
   const [messageCursor, setMessageCursor] = useState();
+  const [checkedMessages, setCheckedMessages] = useState([]);
 
   const [pageInfo, setPageInfo] = useState({});
   const [facets, setFacets] = useState({});
@@ -83,6 +84,8 @@ const MessagesMain = () => {
       .then(response => {
         saveQueryForExport(accountParam + queryParams);
         updateResults(response.data);
+        // deselect any selected messages on successful query
+        setCheckedMessages([]);
         setLoading(false);
       })
       .catch(error => {
@@ -159,8 +162,30 @@ const MessagesMain = () => {
     setFilterQuery(emptyQuery);
   };
 
+  const checkAllMessages = all => {
+    if (all) {
+      setCheckedMessages(messages.map(m => m.id));
+    } else {
+      setCheckedMessages([]);
+    }
+  };
+
+  const checkMessage = messageId => {
+    const messageIndex = checkedMessages.indexOf(messageId);
+    if (messageIndex > -1) {
+      const messagesWithout = [...checkedMessages];
+      messagesWithout.splice(messageIndex, 1);
+      setCheckedMessages(messagesWithout);
+    } else {
+      setCheckedMessages([...checkedMessages, messageId]);
+    }
+  };
+
   const context = {
     account,
+    checkAllMessages,
+    checkMessage,
+    checkedMessages,
     filterQuery,
     setFilterQuery,
     clearFilters,


### PR DESCRIPTION
There's a lot of fuss here, but in short, I had to hoist the message selection action up a few levels so that the containers responsible for handling a successful query could also deselect messages.

I also went ahead and moved the export button back to where it was before.
