### PR TITLE
[RATOM-241] Fixes problems with badge color, adds another component

### DIFF
--- a/src/components/Components/Labels/Badge.js
+++ b/src/components/Components/Labels/Badge.js
@@ -54,9 +54,9 @@ const getBadgeColor = props => {
   return props.isHighlighted ? lighten(baseColor) : baseColor;
 };
 
-const getStatusBadgeColor = props => {
+const getStatusBadgeColor = status => {
   let baseColor;
-  switch (props.status) {
+  switch (status) {
     case STATUSES.CM:
       baseColor = colorBadgeGreen;
       break;
@@ -98,7 +98,7 @@ const AutoCompleteBadgeStyled = styled.div`
 `;
 
 const StatusBadgeStyled = styled(AutoCompleteBadgeStyled)`
-  background-color: ${status => getStatusBadgeColor(status)};
+  background-color: ${props => getStatusBadgeColor(props.status)};
 `;
 
 const BadgeStyled = styled.div`

--- a/src/components/Components/Labels/Badge.js
+++ b/src/components/Components/Labels/Badge.js
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import { colorBadgeBlue, colorBadgeGreen, colorBadgeRed } from '../../../styles/styleVariables';
 
 import { darken, lighten } from '../../../styles/styleUtils/lighten-darken';
+import { STATUSES } from '../../Containers/Accounts/AccountsList/AccountDetails';
 
 const Badge = ({ name, remove, ...props }) => {
   return (
@@ -25,6 +26,14 @@ const AutoCompleteBadge = ({ name, ...props }) => {
   );
 };
 
+const StatusBadge = ({ status, ...props }) => {
+  return (
+    <StatusBadgeStyled status={status} {...props} data-cy="status-badge">
+      <p>{status}</p>
+    </StatusBadgeStyled>
+  );
+};
+
 const getBadgeColor = props => {
   let baseColor;
   switch (props.type) {
@@ -36,6 +45,26 @@ const getBadgeColor = props => {
       break;
     case 'R':
       baseColor = colorBadgeRed;
+      break;
+    default:
+      baseColor = colorBadgeBlue;
+      break;
+  }
+
+  return props.isHighlighted ? lighten(baseColor) : baseColor;
+};
+
+const getStatusBadgeColor = props => {
+  let baseColor;
+  switch (props.status) {
+    case STATUSES.CM:
+      baseColor = colorBadgeGreen;
+      break;
+    case STATUSES.FA || STATUSES.RE:
+      baseColor = colorBadgeRed;
+      break;
+    case STATUSES.CR:
+      baseColor = colorBadgeBlue;
       break;
     default:
       baseColor = colorBadgeBlue;
@@ -66,6 +95,10 @@ const AutoCompleteBadgeStyled = styled.div`
   }
 
   background-color: ${props => getBadgeColor(props)};
+`;
+
+const StatusBadgeStyled = styled(AutoCompleteBadgeStyled)`
+  background-color: ${status => getStatusBadgeColor(status)};
 `;
 
 const BadgeStyled = styled.div`
@@ -105,4 +138,4 @@ const IconStyled = styled.p`
   }
 `;
 
-export { Badge, AutoCompleteBadge };
+export { Badge, AutoCompleteBadge, StatusBadge };

--- a/src/components/Containers/Accounts/AccountsList/AccountDetails.js
+++ b/src/components/Containers/Accounts/AccountsList/AccountDetails.js
@@ -10,14 +10,15 @@ import formatNumber from '../../../../util/formatNumber';
 import dateToIso from '../../../../util/dateToIso';
 
 // Children
-import { Badge } from '../../../Components/Labels/Badge';
+import { StatusBadge } from '../../../Components/Labels/Badge';
 import DotMenu from '../../../Components/Widgets/DotMenu';
 
 export const STATUSES = {
   CR: 'Created',
   IM: 'Importing',
   CM: 'Complete',
-  FA: 'Failed'
+  FA: 'Failed',
+  RE: 'Restoring'
 };
 
 const IconTextStack = ({ item, ...props }) => {
@@ -54,14 +55,9 @@ const AccountDetails = ({ account, asHeader, actions }) => {
     return formatNumber(diff);
   };
 
-  const renderBadge = () => {
-    let badgeStatus;
-    if (asHeader) return null;
-    if (status === 'Created') return null;
-    if (status === 'Importing') badgeStatus = 'normal';
-    if (status === 'Complete') badgeStatus = 'positive';
-    if (status === 'Failed') badgeStatus = 'caution';
-    return <Badge name={status} type={badgeStatus} />;
+  const getHiddenStatus = () => {
+    if (status === STATUSES.IM || status === STATUSES.RE) return true;
+    return false;
   };
 
   return (
@@ -72,7 +68,7 @@ const AccountDetails = ({ account, asHeader, actions }) => {
         </h4>
         <HeaderMeta shouldBeGrey={shouldBeGrey}>
           <p>Inclusive Dates: {getInclusiveDates()}</p>
-          <div>{renderBadge()}</div>
+          <StatusBadge status={status} />
         </HeaderMeta>
       </LeftContent>
 
@@ -97,7 +93,7 @@ const AccountDetails = ({ account, asHeader, actions }) => {
           <p>Last Modified {dateToIso(account.account_last_modified)}</p>
         </ProcessingStatus>
         <DotMenuStyled
-          hidden={!actions ? !actions : status === 'Importing'}
+          hidden={getHiddenStatus()}
           actions={actions}
           data-cy="account-detail-dot-menu"
         />

--- a/src/components/Containers/Accounts/AccountsList/AccountDetails.js
+++ b/src/components/Containers/Accounts/AccountsList/AccountDetails.js
@@ -55,10 +55,7 @@ const AccountDetails = ({ account, asHeader, actions }) => {
     return formatNumber(diff);
   };
 
-  const getHiddenStatus = () => {
-    if (status === STATUSES.IM || status === STATUSES.RE) return true;
-    return false;
-  };
+  const getHiddenStatus = () => status === STATUSES.IM || status === STATUSES.RE;
 
   return (
     <AccountDetailsStyled>

--- a/src/components/Containers/Accounts/AccountsList/AccountsListItem.js
+++ b/src/components/Containers/Accounts/AccountsList/AccountsListItem.js
@@ -36,9 +36,13 @@ const AccountsListItem = ({ account, setAccount, ...props }) => {
     };
 
     if (account.account_status === 'FA') {
+      let displayMsg = 'Restore Account';
+      if (account.files_in_account === 1) {
+        displayMsg = 'Remove Account';
+      }
       actions['normal'] = [];
       actions.caution.push({
-        display: 'Restore Account',
+        display: displayMsg,
         onClick: () => {
           selectAccount(account);
           _deleteFile(account);
@@ -51,7 +55,7 @@ const AccountsListItem = ({ account, setAccount, ...props }) => {
   const _deleteFile = account => {
     Axios.delete(DELETE_FILE, { data: account })
       .then(response => {
-        alert.success('The account has been restored.');
+        alert.success('The account has been restored or removed.');
       })
       .catch(error => {
         alert.error('An error occurred while trying to restore this account.');


### PR DESCRIPTION
This PR adds a new badge. In the process it also restores the appropriate coloring of the badges in the AccountListView.  It also makes a change to messaging. If an account has a single file in a failed status it will prompt the user to "Remove Account" if there are more files with 1 in complete and `n` in failed it will prompt the user to "Restore Account".

During a long restore the account will no longer have the `...` menu and its badge will read `Restoring`

