### PR TITLE
[RATOM-199] remove fake actions from messages list header

### DIFF
--- a/src/components/Containers/Messages/MessagesHeader.js
+++ b/src/components/Containers/Messages/MessagesHeader.js
@@ -17,32 +17,13 @@ const MessagesHeader = () => {
   const { account } = useContext(AccountContext);
   const history = useHistory();
 
-  const actions = {
-    normal: [
-      {
-        display: 'Do a Normal Thing',
-        onClick: () => {
-          alert('thing done.');
-        }
-      }
-    ],
-    caution: [
-      {
-        display: 'Do a Dangerous Thing',
-        onClick: () => {
-          alert('EEEEK.');
-        }
-      }
-    ]
-  };
-
   return (
     <MessagesHeaderStyled>
       <ButtonWrapper>
         <BackButton onClick={() => history.push('/')} />
       </ButtonWrapper>
       <ContentWrapper>
-        {account ? <AccountDetails account={account} actions={actions} asHeader /> : <Spinner />}
+        {account ? <AccountDetails account={account} asHeader /> : <Spinner />}
       </ContentWrapper>
     </MessagesHeaderStyled>
   );


### PR DESCRIPTION
I couldn't find any other filler data that wasn't represented in the ticket.
Everything else was already done, so this was just removing the dot-menu from the messages list view "account header"